### PR TITLE
Async pymongo module error

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,10 +1,9 @@
 """
-MongoDB Database Management with PyMongo Async API
+MongoDB Database Management with Motor (async MongoDB driver)
 """
 from datetime import datetime, timedelta
 from typing import Optional, List, Dict, Any
-from pymongo.asynchronous.mongo_client import AsyncMongoClient
-from pymongo.asynchronous.collection import AsyncCollection
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 from pymongo import IndexModel, ASCENDING, DESCENDING
 from config import Config
 import logging
@@ -13,28 +12,28 @@ logger = logging.getLogger(__name__)
 
 
 class Database:
-    """MongoDB Database Manager using PyMongo Async API"""
+    """MongoDB Database Manager using Motor (async MongoDB driver)"""
     
     def __init__(self):
-        self.client: Optional[AsyncMongoClient] = None
+        self.client: Optional[AsyncIOMotorClient] = None
         self.db = None
         
         # Collections
-        self.users: Optional[AsyncCollection] = None
-        self.coupons: Optional[AsyncCollection] = None
-        self.orders: Optional[AsyncCollection] = None
-        self.auctions: Optional[AsyncCollection] = None
-        self.messages: Optional[AsyncCollection] = None
-        self.payouts: Optional[AsyncCollection] = None
-        self.reviews: Optional[AsyncCollection] = None
-        self.favorites: Optional[AsyncCollection] = None
-        self.disputes: Optional[AsyncCollection] = None
-        self.transactions: Optional[AsyncCollection] = None
+        self.users: Optional[AsyncIOMotorCollection] = None
+        self.coupons: Optional[AsyncIOMotorCollection] = None
+        self.orders: Optional[AsyncIOMotorCollection] = None
+        self.auctions: Optional[AsyncIOMotorCollection] = None
+        self.messages: Optional[AsyncIOMotorCollection] = None
+        self.payouts: Optional[AsyncIOMotorCollection] = None
+        self.reviews: Optional[AsyncIOMotorCollection] = None
+        self.favorites: Optional[AsyncIOMotorCollection] = None
+        self.disputes: Optional[AsyncIOMotorCollection] = None
+        self.transactions: Optional[AsyncIOMotorCollection] = None
         
     async def connect(self):
         """Connect to MongoDB"""
         try:
-            self.client = AsyncMongoClient(Config.MONGODB_URI)
+            self.client = AsyncIOMotorClient(Config.MONGODB_URI)
             self.db = self.client[Config.DATABASE_NAME]
             
             # Initialize collections
@@ -114,7 +113,7 @@ class Database:
     async def close(self):
         """Close database connection"""
         if self.client:
-            await self.client.close()
+            self.client.close()
             logger.info("MongoDB connection closed")
     
     # User Methods


### PR DESCRIPTION
Replaced `pymongo.asynchronous` with `motor` for async MongoDB operations.

The `pymongo.asynchronous` module was causing `ModuleNotFoundError` as it's not consistently available in deployed PyMongo environments. Motor is the recommended and supported async driver for PyMongo. This change also updates `client.close()` to be non-awaitable as per Motor's API.

---
<a href="https://cursor.com/background-agent?bcId=bc-9675c958-5786-4215-b9e5-d5f40c3acd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9675c958-5786-4215-b9e5-d5f40c3acd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

